### PR TITLE
fix: resolve cpu load issue of prepare_uninitialized_buffer

### DIFF
--- a/secio/src/codec/secure_stream.rs
+++ b/secio/src/codec/secure_stream.rs
@@ -147,6 +147,10 @@ where
             Poll::Pending => Poll::Pending,
         }
     }
+
+    unsafe fn prepare_uninitialized_buffer(&self, buf: &mut [std::mem::MaybeUninit<u8>]) -> bool {
+        self.socket.get_ref().prepare_uninitialized_buffer(buf)
+    }
 }
 
 impl<T> AsyncWrite for SecureStream<T>

--- a/tentacle/src/substream.rs
+++ b/tentacle/src/substream.rs
@@ -1036,4 +1036,8 @@ impl AsyncRead for PatchedReadPart {
             Poll::Ready(Ok(n))
         }
     }
+
+    unsafe fn prepare_uninitialized_buffer(&self, buf: &mut [std::mem::MaybeUninit<u8>]) -> bool {
+        self.io.prepare_uninitialized_buffer(buf)
+    }
 }

--- a/tentacle/src/transports/mod.rs
+++ b/tentacle/src/transports/mod.rs
@@ -237,6 +237,13 @@ mod os {
                 MultiStream::Ws(inner) => Pin::new(inner).poll_read(cx, buf),
             }
         }
+
+        unsafe fn prepare_uninitialized_buffer(
+            &self,
+            _buf: &mut [std::mem::MaybeUninit<u8>],
+        ) -> bool {
+            false
+        }
     }
 
     impl AsyncWrite for MultiStream {

--- a/yamux/src/stream.rs
+++ b/yamux/src/stream.rs
@@ -385,6 +385,10 @@ impl AsyncRead for StreamHandle {
 
         Poll::Ready(Ok(n))
     }
+
+    unsafe fn prepare_uninitialized_buffer(&self, _buf: &mut [std::mem::MaybeUninit<u8>]) -> bool {
+        false
+    }
 }
 
 impl AsyncWrite for StreamHandle {


### PR DESCRIPTION
After doing some basic profiling, I found that a lot of CPU was spent on memset, and traced the code to find that it was caused by not implementing the [prepare_uninitialized_buffer](https://docs.rs/tokio/0.2.24/tokio/io/trait.AsyncRead.html#method.prepare_uninitialized_buffer) method

below is the bench result comparison

```
After counting 10 cycles, estimated total time spent on task "10mb_benchmark_with_secio" is 3.0800651s
task name: 10mb_benchmark_with_secio
cycles: 100
total cost: 3.019923503s
average: 30.199235ms
median: 30.015518ms
max: 42.400898ms
min: 28.272243ms
```

v.s

```
After counting 10 cycles, estimated total time spent on task "10mb_benchmark_with_secio" is 1.707217s
task name: 10mb_benchmark_with_secio
cycles: 100
total cost: 1.75304821s
average: 17.530482ms
median: 17.24187ms
max: 35.465816ms
min: 16.76556ms
```