### PR TITLE
feat: support custom singer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ clippy:
 
 test:
 	$(Change_Work_Path) && RUSTFLAGS='-W warnings' RUST_BACKTRACE=full cargo test --all --features ws,unstable,tls,upnp
-
+	$(Change_Work_Path) && RUSTFLAGS='-W warnings' RUST_BACKTRACE=full cargo test --all --features ws,unstable,tls,upnp,secio-async-trait
 fuzz:
 	cargo +nightly fuzz run secio_crypto_decrypt_cipher -- -max_total_time=60
 	cargo +nightly fuzz run secio_crypto_encrypt_cipher -- -max_total_time=60
@@ -44,7 +44,7 @@ features-check:
 	$(Change_Work_Path) && cargo build --features async-runtime,async-timer,unstable --no-default-features
 	# required wasm32-unknown-unknown target
 	$(Change_Work_Path) && cargo build --features wasm-timer,unstable --no-default-features --target=wasm32-unknown-unknown
-
+	$(Change_Work_Path) && cargo build --features wasm-timer,unstable,secio-async-trait --no-default-features --target=wasm32-unknown-unknown
 bench_p2p:
 	cd bench && cargo run --release
 

--- a/bench/src/main.rs
+++ b/bench/src/main.rs
@@ -31,9 +31,9 @@ enum Notify {
     Message(bytes::Bytes),
 }
 
-pub fn create<F>(secio: bool, meta: ProtocolMeta, shandle: F) -> Service<F>
+pub fn create<F>(secio: bool, meta: ProtocolMeta, shandle: F) -> Service<F, SecioKeyPair>
 where
-    F: ServiceHandle + Unpin,
+    F: ServiceHandle + Unpin + 'static,
 {
     let builder = ServiceBuilder::default()
         .insert_protocol(meta)

--- a/secio/Cargo.toml
+++ b/secio/Cargo.toml
@@ -21,6 +21,7 @@ futures = { version = "0.3.0" }
 tokio = { version = "1.0", features = ["io-util"] }
 tokio-util = { version = "0.7.0", features = ["codec"] }
 log = "0.4.1"
+async-trait = { version = "0.1", optional = true }
 
 molecule = "0.7.0"
 

--- a/secio/src/codec/hmac_compat/openssl_impl.rs
+++ b/secio/src/codec/hmac_compat/openssl_impl.rs
@@ -1,6 +1,5 @@
 use openssl::{
     hash::MessageDigest,
-    memcmp,
     pkey::{PKey, Private},
     sign::Signer,
 };
@@ -15,6 +14,7 @@ pub struct Hmac {
 
 impl Hmac {
     /// Returns the size of the hash in bytes.
+    #[cfg(test)]
     #[inline]
     pub fn num_bytes(&self) -> usize {
         self.digest.size()
@@ -32,6 +32,7 @@ impl Hmac {
     }
 
     /// Signs the data.
+    #[cfg(test)]
     pub fn sign(&mut self, crypted_data: &[u8]) -> Vec<u8> {
         let mut sign = Signer::new(self.digest, &self.key).expect("init openssl signer ctx fail");
         sign.update(crypted_data).expect("openssl hmac update fail");
@@ -39,12 +40,13 @@ impl Hmac {
     }
 
     /// Verifies that the data matches the expected hash.
+    #[cfg(test)]
     pub fn verify(&mut self, crypted_data: &[u8], expected_hash: &[u8]) -> bool {
         let n = self.sign(crypted_data);
         if n.len() != expected_hash.len() {
             return false;
         }
-        memcmp::eq(&n, expected_hash)
+        openssl::memcmp::eq(&n, expected_hash)
     }
 
     /// Return a multi-step hmac context

--- a/secio/src/codec/hmac_compat/ring_impl.rs
+++ b/secio/src/codec/hmac_compat/ring_impl.rs
@@ -6,6 +6,7 @@ pub struct Hmac(ring::hmac::Key);
 
 impl Hmac {
     /// Returns the size of the hash in bytes.
+    #[cfg(test)]
     #[inline]
     pub fn num_bytes(&self) -> usize {
         self.0.algorithm().digest_algorithm().output_len
@@ -20,11 +21,13 @@ impl Hmac {
     }
 
     /// Signs the data.
+    #[cfg(test)]
     pub fn sign(&mut self, crypted_data: &[u8]) -> ring::hmac::Tag {
         ring::hmac::sign(&self.0, crypted_data)
     }
 
     /// Verifies that the data matches the expected hash.
+    #[cfg(test)]
     pub fn verify(&mut self, crypted_data: &[u8], expected_hash: &[u8]) -> bool {
         ring::hmac::verify(&self.0, crypted_data, expected_hash).is_ok()
     }

--- a/secio/src/codec/mod.rs
+++ b/secio/src/codec/mod.rs
@@ -3,7 +3,4 @@
 /// Encryption and decryption stream
 pub mod secure_stream;
 // hmac compatible
-mod hmac_compat;
-
-// TODO: remove this pub use for next break version
-pub use hmac_compat::Hmac;
+pub(crate) mod hmac_compat;

--- a/secio/src/error.rs
+++ b/secio/src/error.rs
@@ -14,6 +14,9 @@ pub enum SecioError {
     /// Crypto error
     CryptoError,
 
+    /// Signer not support
+    NotSupportSigner,
+
     /// Failed to generate ephemeral key.
     EphemeralKeyGenerationFailed,
 
@@ -28,9 +31,6 @@ pub enum SecioError {
 
     /// The received frame was of invalid length.
     FrameTooShort,
-
-    /// The hashes of the message didn't match.
-    HmacNotMatching,
 
     /// Connect yourself
     ConnectSelf,
@@ -58,11 +58,11 @@ impl PartialEq for SecioError {
             | (NoSupportIntersection, NoSupportIntersection)
             | (NonceVerificationFailed, NonceVerificationFailed)
             | (FrameTooShort, FrameTooShort)
-            | (HmacNotMatching, HmacNotMatching)
             | (ConnectSelf, ConnectSelf)
             | (HandshakeParsingFailure, HandshakeParsingFailure)
             | (SignatureVerificationFailed, SignatureVerificationFailed)
-            | (InvalidMessage, InvalidMessage) => true,
+            | (InvalidMessage, InvalidMessage)
+            | (NotSupportSigner, NotSupportSigner) => true,
             _ => false,
         }
     }
@@ -113,12 +113,12 @@ impl fmt::Display for SecioError {
             SecioError::NoSupportIntersection => write!(f, "No Support Intersection"),
             SecioError::NonceVerificationFailed => write!(f, "Nonce Verification Failed"),
             SecioError::FrameTooShort => write!(f, "Frame Too Short"),
-            SecioError::HmacNotMatching => write!(f, "Hmac Not Matching"),
             SecioError::ConnectSelf => write!(f, "Connect Self"),
             SecioError::HandshakeParsingFailure => write!(f, "Handshake Parsing Failure"),
             SecioError::InvalidMessage => write!(f, "Invalid Message"),
             SecioError::SignatureVerificationFailed => write!(f, "Signature Verification Failed"),
             SecioError::InvalidProposition(e) => write!(f, "Invalid Proposition: {}", e),
+            SecioError::NotSupportSigner => write!(f, "Signer operation not supported"),
         }
     }
 }

--- a/secio/src/handshake/handshake_struct.rs
+++ b/secio/src/handshake/handshake_struct.rs
@@ -119,34 +119,19 @@ impl Exchange {
 
 /// Public Key
 #[derive(Clone, PartialEq, Ord, PartialOrd, Eq, Hash)]
-pub enum PublicKey {
-    /// Secp256k1
-    Secp256k1(Vec<u8>),
+pub struct PublicKey {
+    pub(crate) key: Vec<u8>,
 }
 
 impl PublicKey {
     /// Get inner data
     pub fn inner_ref(&self) -> &[u8] {
-        match self {
-            PublicKey::Secp256k1(ref key) => key,
-        }
+        &self.key
     }
 
     /// Get inner data
     pub fn inner(self) -> Vec<u8> {
-        match self {
-            PublicKey::Secp256k1(key) => key,
-        }
-    }
-
-    /// Creates a public key directly from a slice
-    pub fn secp256k1_raw_key<K>(key: K) -> Result<Self, crate::error::SecioError>
-    where
-        K: AsRef<[u8]>,
-    {
-        crate::secp256k1_compat::pubkey_from_slice(key.as_ref())
-            .map(|key| PublicKey::Secp256k1(crate::secp256k1_compat::serialize_pubkey(&key)))
-            .map_err(|_| crate::error::SecioError::SecretGenerationFailed)
+        self.key
     }
 
     /// Encode with molecule
@@ -164,10 +149,11 @@ impl PublicKey {
     pub fn decode(data: &[u8]) -> Option<Self> {
         let reader = handshake_mol::PublicKeyReader::from_compatible_slice(data).ok()?;
         let union = reader.to_enum();
+
         match union {
-            handshake_mol::PublicKeyUnionReader::Secp256k1(reader) => {
-                Some(PublicKey::Secp256k1(reader.raw_data().to_owned()))
-            }
+            handshake_mol::PublicKeyUnionReader::Secp256k1(reader) => Some(PublicKey {
+                key: reader.raw_data().to_owned(),
+            }),
         }
     }
 
@@ -190,7 +176,7 @@ impl fmt::Debug for PublicKey {
 #[cfg(test)]
 mod tests {
     use super::{Exchange, Propose, PublicKey};
-    use crate::SecioKeyPair;
+    use crate::{SecioKeyPair, Signer};
     use bytes::Bytes;
 
     #[test]
@@ -230,13 +216,13 @@ mod tests {
         let raw = privkey.public_key();
         let inner = raw.inner_ref();
 
-        let other = PublicKey::secp256k1_raw_key(inner).unwrap();
-        assert_eq!(raw, other);
+        let other = SecioKeyPair::pubkey_from_slice(inner).unwrap();
+        assert_eq!(raw.inner_ref(), other.serialize());
         let uncompressed = crate::secp256k1_compat::pubkey_from_slice(inner)
             .map(|key| key.serialize_uncompressed().to_vec())
             .unwrap();
 
-        let other_1 = PublicKey::secp256k1_raw_key(uncompressed).unwrap();
-        assert_eq!(raw, other_1);
+        let other_1 = SecioKeyPair::pubkey_from_slice(&uncompressed).unwrap();
+        assert_eq!(raw.inner_ref(), other_1.serialize());
     }
 }

--- a/secio/src/handshake/mod.rs
+++ b/secio/src/handshake/mod.rs
@@ -1,11 +1,13 @@
 /// Most of the code for this module comes from `rust-libp2p`, but modified some logic(struct).
 use crate::{
     crypto::cipher::CipherType, dh_compat::KeyAgreement, error::SecioError,
-    handshake::procedure::handshake, support, Digest, EphemeralPublicKey, PublicKey, SecioKeyPair,
+    handshake::procedure::handshake, support, Digest, EphemeralPublicKey, PublicKey,
 };
 
 use crate::codec::secure_stream::SecureStream;
 use tokio::io::{AsyncRead, AsyncWrite};
+
+use std::sync::Arc;
 
 #[rustfmt::skip]
 #[allow(clippy::all)]
@@ -20,19 +22,22 @@ const MAX_FRAME_SIZE: usize = 1024 * 1024 * 8;
 
 /// Config for Secio
 #[derive(Debug, Clone)]
-pub struct Config {
-    pub(crate) key: SecioKeyPair,
+pub struct Config<K> {
+    pub(crate) key: Arc<K>,
     pub(crate) agreements_proposal: Option<String>,
     pub(crate) ciphers_proposal: Option<String>,
     pub(crate) digests_proposal: Option<String>,
     pub(crate) max_frame_length: usize,
 }
 
-impl Config {
+impl<K> Config<K>
+where
+    K: crate::Signer,
+{
     /// Create config
-    pub fn new(key_pair: SecioKeyPair) -> Self {
+    pub fn new(key_pair: K) -> Self {
         Config {
-            key: key_pair,
+            key: Arc::new(key_pair),
             agreements_proposal: None,
             ciphers_proposal: None,
             digests_proposal: None,

--- a/secio/src/lib.rs
+++ b/secio/src/lib.rs
@@ -63,7 +63,9 @@ impl SecioKeyPair {
         match self.inner {
             KeyPairInner::Secp256k1 { ref private } => {
                 let pubkey = crate::secp256k1_compat::from_secret_key(private);
-                PublicKey::Secp256k1(crate::secp256k1_compat::serialize_pubkey(&pubkey))
+                PublicKey {
+                    key: crate::secp256k1_compat::serialize_pubkey(&pubkey),
+                }
             }
         }
     }
@@ -74,11 +76,17 @@ impl SecioKeyPair {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 enum KeyPairInner {
     Secp256k1 {
         private: crate::secp256k1_compat::SecretKey,
     },
+}
+
+impl std::fmt::Debug for KeyPairInner {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("KeyPair").finish()
+    }
 }
 
 /// Possible digest algorithms.
@@ -98,5 +106,154 @@ impl Digest {
             Digest::Sha256 => 256 / 8,
             Digest::Sha512 => 512 / 8,
         }
+    }
+}
+
+/// Signer on ecdh procedure
+#[cfg_attr(all(target_arch = "wasm32", feature = "async-trait"), async_trait::async_trait(?Send))]
+#[cfg_attr(
+    all(not(target_arch = "wasm32"), feature = "async-trait"),
+    async_trait::async_trait
+)]
+pub trait Signer: std::fmt::Debug + Send + Sync + 'static {
+    /// Error
+    type Error: Into<crate::error::SecioError>;
+    /// Public key
+    type Pubkey: Pubkey;
+
+    /// Constructs a signature for `msg` using the secret key `sk`
+    #[cfg(feature = "async-trait")]
+    async fn sign_ecdsa_async(&self, message: &[u8]) -> Result<Vec<u8>, Self::Error> {
+        self.sign_ecdsa(message)
+    }
+
+    /// Constructs a signature for `msg` using the secret key `sk`
+    fn sign_ecdsa(&self, message: &[u8]) -> Result<Vec<u8>, Self::Error>;
+
+    /// Creates a new public key from a [`Signer`].
+    fn pubkey(&self) -> Self::Pubkey;
+
+    /// Recover public key from slice
+    fn pubkey_from_slice(key: &[u8]) -> Result<Self::Pubkey, Self::Error>;
+}
+
+/// Public key for Signer
+pub trait Pubkey: std::fmt::Debug + Send + Sync + 'static {
+    /// Checks that `sig` is a valid ECDSA signature for `msg` using the public
+    /// key `pubkey`.
+    fn verify_ecdsa(&self, message: &[u8], signature: &[u8]) -> bool;
+
+    /// serialized key into a bytes
+    fn serialize(&self) -> Vec<u8>;
+}
+
+impl Signer for SecioKeyPair {
+    type Error = error::SecioError;
+    type Pubkey = secp256k1_compat::PublicKey;
+
+    fn sign_ecdsa(&self, message: &[u8]) -> Result<Vec<u8>, Self::Error> {
+        let msg = match crate::secp256k1_compat::message_from_slice(message) {
+            Ok(m) => m,
+            Err(_) => {
+                log::debug!("message has wrong format");
+                return Err(error::SecioError::InvalidMessage);
+            }
+        };
+        let signature = match self.inner {
+            KeyPairInner::Secp256k1 { ref private } => crate::secp256k1_compat::sign(&msg, private),
+        };
+
+        Ok(crate::secp256k1_compat::signature_to_vec(signature))
+    }
+
+    fn pubkey(&self) -> Self::Pubkey {
+        match self.inner {
+            KeyPairInner::Secp256k1 { ref private } => {
+                crate::secp256k1_compat::from_secret_key(private)
+            }
+        }
+    }
+
+    fn pubkey_from_slice(key: &[u8]) -> Result<Self::Pubkey, Self::Error>
+    where
+        Self: Sized,
+    {
+        crate::secp256k1_compat::pubkey_from_slice(key.as_ref())
+            .map_err(|_| crate::error::SecioError::SecretGenerationFailed)
+    }
+}
+
+impl Pubkey for secp256k1_compat::PublicKey {
+    fn verify_ecdsa(&self, message: &[u8], signature: &[u8]) -> bool {
+        let signature = crate::secp256k1_compat::signature_from_der(signature);
+        let msg = crate::secp256k1_compat::message_from_slice(message);
+
+        if let (Ok(signature), Ok(message)) = (signature, msg) {
+            if !crate::secp256k1_compat::verify(&message, &signature, self) {
+                log::debug!("failed to verify the remote's signature");
+                return false;
+            }
+        } else {
+            log::debug!("remote's secp256k1 signature has wrong format");
+            return false;
+        }
+        true
+    }
+
+    fn serialize(&self) -> Vec<u8> {
+        crate::secp256k1_compat::serialize_pubkey(self)
+    }
+}
+
+impl<T> Signer for std::sync::Arc<T>
+where
+    T: Signer,
+{
+    type Error = <T as Signer>::Error;
+    type Pubkey = <T as Signer>::Pubkey;
+
+    fn sign_ecdsa(&self, message: &[u8]) -> Result<Vec<u8>, Self::Error> {
+        self.as_ref().sign_ecdsa(message)
+    }
+
+    fn pubkey(&self) -> Self::Pubkey {
+        self.as_ref().pubkey()
+    }
+
+    fn pubkey_from_slice(key: &[u8]) -> Result<Self::Pubkey, Self::Error>
+    where
+        Self: Sized,
+    {
+        <T as Signer>::pubkey_from_slice(key)
+    }
+}
+
+impl Signer for () {
+    type Error = error::SecioError;
+    type Pubkey = ();
+
+    fn sign_ecdsa(&self, _message: &[u8]) -> Result<Vec<u8>, Self::Error> {
+        Err(error::SecioError::NotSupportSigner)
+    }
+
+    fn pubkey(&self) -> Self::Pubkey {
+        ()
+    }
+
+    fn pubkey_from_slice(_key: &[u8]) -> Result<Self::Pubkey, Self::Error>
+    where
+        Self: Sized,
+    {
+        Ok(())
+    }
+}
+
+impl Pubkey for () {
+    fn verify_ecdsa(&self, _message: &[u8], _signature: &[u8]) -> bool {
+        false
+    }
+
+    fn serialize(&self) -> Vec<u8> {
+        Vec::new()
     }
 }

--- a/tentacle/Cargo.toml
+++ b/tentacle/Cargo.toml
@@ -43,7 +43,7 @@ molecule = "0.7.0"
 igd = { version = "0.12", optional = true }
 
 #tls
-tokio-rustls = { version = "0.23.0", optional = true }
+tokio-rustls = { version = "0.24.0", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 # rand 0.8 not support wasm32
@@ -76,6 +76,7 @@ default = ["tokio-runtime", "tokio-timer"]
 ws = ["tokio-tungstenite"]
 tls = ["tokio-rustls"]
 upnp = ["igd"]
+secio-async-trait = ["secio/async-trait"]
 unstable = []
 
 openssl-vendored = ["secio/openssl-vendored"]

--- a/tentacle/examples/block_send.rs
+++ b/tentacle/examples/block_send.rs
@@ -13,9 +13,9 @@ use tentacle::{
     ProtocolId,
 };
 
-pub fn create<F>(secio: bool, meta: ProtocolMeta, shandle: F) -> Service<F>
+pub fn create<F>(secio: bool, meta: ProtocolMeta, shandle: F) -> Service<F, SecioKeyPair>
 where
-    F: ServiceHandle + Unpin,
+    F: ServiceHandle + Unpin + Send + 'static,
 {
     let builder = ServiceBuilder::default().insert_protocol(meta);
 

--- a/tentacle/examples/heavy_task_schedule.rs
+++ b/tentacle/examples/heavy_task_schedule.rs
@@ -114,9 +114,9 @@ impl ServiceHandle for SHandle {
     }
 }
 
-pub fn create<F>(secio: bool, meta: ProtocolMeta, shandle: F) -> Service<F>
+pub fn create<F>(secio: bool, meta: ProtocolMeta, shandle: F) -> Service<F, SecioKeyPair>
 where
-    F: ServiceHandle + Unpin,
+    F: ServiceHandle + Unpin + Send + 'static,
 {
     let builder = ServiceBuilder::default().insert_protocol(meta);
 

--- a/tentacle/examples/simple.rs
+++ b/tentacle/examples/simple.rs
@@ -182,7 +182,7 @@ fn main() {
 // There are many other options in service builder, which are not used here, please refer to the documentation for details
 //
 // For the foreseeable future, there is no idea of dynamic addition and deletion agreements
-fn create_server() -> Service<SHandle> {
+fn create_server() -> Service<SHandle, SecioKeyPair> {
     ServiceBuilder::default()
         .insert_protocol(create_meta(0.into()))
         .insert_protocol(create_meta(1.into()))
@@ -195,7 +195,7 @@ fn create_server() -> Service<SHandle> {
 /// Proto 2 open failure
 ///
 /// Because server only supports 0,1
-fn create_client() -> Service<SHandle> {
+fn create_client() -> Service<SHandle, SecioKeyPair> {
     ServiceBuilder::default()
         .insert_protocol(create_meta(0.into()))
         .insert_protocol(create_meta(1.into()))

--- a/tentacle/examples/simple_using_spawn.rs
+++ b/tentacle/examples/simple_using_spawn.rs
@@ -126,7 +126,7 @@ fn main() {
     }
 }
 
-fn create_server() -> Service<SHandle> {
+fn create_server() -> Service<SHandle, SecioKeyPair> {
     ServiceBuilder::default()
         .insert_protocol(create_meta(0.into()))
         .insert_protocol(create_meta(1.into()))
@@ -139,7 +139,7 @@ fn create_server() -> Service<SHandle> {
 /// Proto 2 open failure
 ///
 /// Because server only supports 0,1
-fn create_client() -> Service<SHandle> {
+fn create_client() -> Service<SHandle, SecioKeyPair> {
     ServiceBuilder::default()
         .insert_protocol(create_meta(0.into()))
         .insert_protocol(create_meta(1.into()))

--- a/tentacle/examples/use_poll.rs
+++ b/tentacle/examples/use_poll.rs
@@ -66,7 +66,7 @@ fn create_meta(id: ProtocolId, recv: Receiver<()>) -> ProtocolMeta {
         .build()
 }
 
-fn create_server(recv: Receiver<()>) -> Service<SHandle> {
+fn create_server(recv: Receiver<()>) -> Service<SHandle, SecioKeyPair> {
     ServiceBuilder::default()
         .insert_protocol(create_meta(0.into(), recv))
         .key_pair(SecioKeyPair::secp256k1_generated())

--- a/tentacle/src/builder.rs
+++ b/tentacle/src/builder.rs
@@ -7,7 +7,7 @@ use tokio_util::codec::LengthDelimitedCodec;
 use crate::service::config::TlsConfig;
 use crate::{
     protocol_select::SelectFn,
-    secio::SecioKeyPair,
+    secio::Signer,
     service::{
         config::{Meta, ServiceConfig},
         ProtocolHandle, ProtocolMeta, Service, TcpSocket,
@@ -18,24 +18,37 @@ use crate::{
 };
 
 /// Builder for Service
-#[derive(Default)]
-pub struct ServiceBuilder {
+pub struct ServiceBuilder<K> {
     inner: IntMap<ProtocolId, ProtocolMeta>,
-    key_pair: Option<SecioKeyPair>,
+    key_pair: Option<Arc<K>>,
     forever: bool,
     config: ServiceConfig,
 }
 
-impl ServiceBuilder {
+impl<K> Default for ServiceBuilder<K> {
+    fn default() -> Self {
+        Self {
+            key_pair: None,
+            inner: IntMap::default(),
+            forever: false,
+            config: ServiceConfig::default(),
+        }
+    }
+}
+
+impl<K> ServiceBuilder<K>
+where
+    K: Signer,
+{
     /// New a default empty builder
     pub fn new() -> Self {
         Default::default()
     }
 
     /// Combine the configuration of this builder with service handle to create a Service.
-    pub fn build<H>(self, handle: H) -> Service<H>
+    pub fn build<H>(self, handle: H) -> Service<H, K>
     where
-        H: ServiceHandle + Unpin,
+        H: ServiceHandle + Unpin + 'static,
     {
         Service::new(self.inner, handle, self.key_pair, self.forever, self.config)
     }
@@ -49,8 +62,8 @@ impl ServiceBuilder {
     /// Enable encrypted communication mode.
     ///
     /// If you do not need encrypted communication, you do not need to call this method
-    pub fn key_pair(mut self, key_pair: SecioKeyPair) -> Self {
-        self.key_pair = Some(key_pair);
+    pub fn key_pair(mut self, key_pair: K) -> Self {
+        self.key_pair = Some(Arc::new(key_pair));
         self
     }
 
@@ -157,7 +170,7 @@ impl ServiceBuilder {
     ///
     /// for example, set all tcp bind to `127.0.0.1:1080`, set keepalive:
     ///
-    /// ```rust
+    /// ```ignore
     ///  use socket2;
     ///  use tentacle::{service::TcpSocket, builder::ServiceBuilder};
     ///  #[cfg(unix)]

--- a/tentacle/src/service.rs
+++ b/tentacle/src/service.rs
@@ -1,6 +1,7 @@
 use futures::{channel::mpsc, future::poll_fn, prelude::*, stream::StreamExt, SinkExt};
 use log::{debug, error, trace};
 use nohash_hasher::IntMap;
+use secio::Signer;
 use std::{
     borrow::Cow,
     collections::{HashMap, HashSet},
@@ -22,8 +23,7 @@ use crate::{
     protocol_handle_stream::{
         ServiceProtocolEvent, ServiceProtocolStream, SessionProtocolEvent, SessionProtocolStream,
     },
-    protocol_select::ProtocolInfo,
-    secio::{PublicKey, SecioKeyPair},
+    secio::PublicKey,
     service::{
         config::{ServiceConfig, State},
         event::{ServiceEventAndError, ServiceTask},
@@ -34,7 +34,6 @@ use crate::{
     traits::ServiceHandle,
     transports::{MultiIncoming, MultiTransport, Transport},
     utils::extract_peer_id,
-    yamux::Config as YamuxConfig,
     ProtocolId, SessionId,
 };
 
@@ -57,12 +56,14 @@ pub use crate::service::config::TlsConfig;
 
 type Result<T> = std::result::Result<T, TransportErrorKind>;
 
-struct InnerService {
+struct InnerService<K> {
     protocol_configs: IntMap<ProtocolId, ProtocolMeta>,
 
     sessions: IntMap<SessionId, SessionController>,
 
     multi_transport: MultiTransport,
+
+    key_pair: Option<Arc<K>>,
 
     listens: HashSet<Multiaddr>,
 
@@ -105,7 +106,7 @@ struct InnerService {
 }
 
 /// An abstraction of p2p service, currently only supports TCP/websocket protocol
-pub struct Service<T> {
+pub struct Service<T, K> {
     /// Can be upgrade to list service level protocols
     handle: T,
     service_context: ServiceContext,
@@ -114,18 +115,19 @@ pub struct Service<T> {
     // Future task manager
     future_task_manager: Option<FutureTaskManager>,
 
-    inner_service: Option<InnerService>,
+    inner_service: Option<InnerService<K>>,
 }
 
-impl<T> Service<T>
+impl<T, K> Service<T, K>
 where
     T: ServiceHandle + Unpin,
+    K: Signer,
 {
     /// New a Service
     pub(crate) fn new(
         protocol_configs: IntMap<ProtocolId, ProtocolMeta>,
         handle: T,
-        key_pair: Option<SecioKeyPair>,
+        key_pair: Option<Arc<K>>,
         forever: bool,
         config: ServiceConfig,
     ) -> Self {
@@ -133,13 +135,6 @@ where
             mpsc::channel(config.session_config.channel_size);
         let (task_sender, task_receiver) =
             priority_mpsc::channel(config.session_config.channel_size);
-        let proto_infos = protocol_configs
-            .values()
-            .map(|meta| {
-                let proto_info = ProtocolInfo::new(&meta.name(), meta.support_versions());
-                (meta.id(), proto_info)
-            })
-            .collect();
         let (future_task_sender, future_task_receiver) =
             mpsc::channel(config.session_config.channel_size);
         let (user_handle_sender, user_handle_receiver) =
@@ -152,8 +147,7 @@ where
             None
         };
 
-        let service_context =
-            ServiceContext::new(task_sender, proto_infos, key_pair, shutdown.clone());
+        let service_context = ServiceContext::new(task_sender, shutdown.clone());
 
         Service {
             handle,
@@ -170,6 +164,7 @@ where
                 before_sends: HashMap::default(),
                 handle_sender: user_handle_sender,
                 future_task_sender,
+                key_pair,
                 multi_transport: {
                     #[cfg(target_arch = "wasm32")]
                     let transport = MultiTransport::new(config.timeout);
@@ -198,42 +193,6 @@ where
                 wait_handle: Vec::new(),
             }),
         }
-    }
-
-    /// Yamux config for service
-    ///
-    /// Panic when max_frame_length < yamux_max_window_size
-    pub fn yamux_config(mut self, config: YamuxConfig) -> Self {
-        assert!(
-            self.inner_service.as_ref().unwrap().config.max_frame_length as u32
-                >= config.max_stream_window_size
-        );
-        self.inner_service
-            .as_mut()
-            .unwrap()
-            .config
-            .session_config
-            .yamux_config = config;
-        self
-    }
-
-    /// Secio max frame length
-    ///
-    /// Panic when max_frame_length < yamux_max_window_size
-    pub fn max_frame_length(mut self, size: usize) -> Self {
-        assert!(
-            size as u32
-                >= self
-                    .inner_service
-                    .as_ref()
-                    .unwrap()
-                    .config
-                    .session_config
-                    .yamux_config
-                    .max_stream_window_size
-        );
-        self.inner_service.as_mut().unwrap().config.max_frame_length = size;
-        self
     }
 
     /// Listen on the given address.
@@ -323,12 +282,15 @@ where
     }
 }
 
-impl InnerService {
+impl<K> InnerService<K>
+where
+    K: Signer,
+{
     #[cfg(not(target_arch = "wasm32"))]
     fn spawn_listener(&mut self, incoming: MultiIncoming, listen_address: Multiaddr) {
         let listener = Listener {
             inner: incoming,
-            key_pair: self.service_context.key_pair().cloned(),
+            key_pair: self.key_pair.clone(),
             event_sender: self.session_event_sender.clone(),
             max_frame_length: self.config.max_frame_length,
             timeout: self.config.timeout,
@@ -383,7 +345,7 @@ impl InnerService {
         self.dial_protocols.insert(address.clone(), target);
         let dial_future = self.multi_transport.clone().dial(address.clone())?;
 
-        let key_pair = self.service_context.key_pair().cloned();
+        let key_pair = self.key_pair.clone();
         let timeout = self.config.timeout;
         let max_frame_length = self.config.max_frame_length;
 
@@ -561,7 +523,7 @@ impl InnerService {
             ty,
             remote_address,
             listen_address,
-            key_pair: self.service_context.key_pair().cloned(),
+            key_pair: self.key_pair.clone(),
             event_sender: self.session_event_sender.clone(),
             max_frame_length: self.config.max_frame_length,
             timeout: self.config.timeout,

--- a/tentacle/tests/test_before_function.rs
+++ b/tentacle/tests/test_before_function.rs
@@ -18,9 +18,9 @@ use tentacle::{
     ProtocolId,
 };
 
-pub fn create<F>(secio: bool, meta: ProtocolMeta, shandle: F) -> Service<F>
+pub fn create<F>(secio: bool, meta: ProtocolMeta, shandle: F) -> Service<F, SecioKeyPair>
 where
-    F: ServiceHandle + Unpin,
+    F: ServiceHandle + Unpin + 'static,
 {
     let builder = ServiceBuilder::default().insert_protocol(meta);
 

--- a/tentacle/tests/test_block_future_task.rs
+++ b/tentacle/tests/test_block_future_task.rs
@@ -9,9 +9,9 @@ use tentacle::{
     ProtocolId,
 };
 
-pub fn create<F>(meta: ProtocolMeta, shandle: F) -> Service<F>
+pub fn create<F>(meta: ProtocolMeta, shandle: F) -> Service<F, ()>
 where
-    F: ServiceHandle + Unpin,
+    F: ServiceHandle + Unpin + 'static,
 {
     ServiceBuilder::default()
         .insert_protocol(meta)

--- a/tentacle/tests/test_block_send.rs
+++ b/tentacle/tests/test_block_send.rs
@@ -18,9 +18,9 @@ use tentacle::{
     ProtocolId,
 };
 
-pub fn create<F>(secio: bool, meta: ProtocolMeta, shandle: F) -> Service<F>
+pub fn create<F>(secio: bool, meta: ProtocolMeta, shandle: F) -> Service<F, SecioKeyPair>
 where
-    F: ServiceHandle + Unpin,
+    F: ServiceHandle + Unpin + 'static,
 {
     let builder = ServiceBuilder::default().insert_protocol(meta);
 

--- a/tentacle/tests/test_block_send_session.rs
+++ b/tentacle/tests/test_block_send_session.rs
@@ -18,9 +18,9 @@ use tentacle::{
     ProtocolId,
 };
 
-pub fn create<F>(secio: bool, meta: ProtocolMeta, shandle: F) -> Service<F>
+pub fn create<F>(secio: bool, meta: ProtocolMeta, shandle: F) -> Service<F, SecioKeyPair>
 where
-    F: ServiceHandle + Unpin,
+    F: ServiceHandle + Unpin + 'static,
 {
     let builder = ServiceBuilder::default().insert_protocol(meta);
 

--- a/tentacle/tests/test_close.rs
+++ b/tentacle/tests/test_close.rs
@@ -11,9 +11,13 @@ use tentacle::{
 
 use std::{sync::mpsc::channel, thread, time::Duration};
 
-pub fn create<F>(secio: bool, metas: impl Iterator<Item = ProtocolMeta>, shandle: F) -> Service<F>
+pub fn create<F>(
+    secio: bool,
+    metas: impl Iterator<Item = ProtocolMeta>,
+    shandle: F,
+) -> Service<F, SecioKeyPair>
 where
-    F: ServiceHandle + Unpin,
+    F: ServiceHandle + Unpin + 'static,
 {
     let mut builder = ServiceBuilder::default().forever(true);
 
@@ -163,7 +167,7 @@ fn test(secio: bool, shutdown: bool) {
 }
 
 fn start_service<F>(
-    mut service: Service<F>,
+    mut service: Service<F, SecioKeyPair>,
     listen_addr: Multiaddr,
     handle: &tokio::runtime::Handle,
 ) where

--- a/tentacle/tests/test_dial.rs
+++ b/tentacle/tests/test_dial.rs
@@ -18,9 +18,9 @@ use tentacle::{
     ProtocolId, SessionId,
 };
 
-pub fn create<F>(secio: bool, meta: ProtocolMeta, shandle: F) -> Service<F>
+pub fn create<F>(secio: bool, meta: ProtocolMeta, shandle: F) -> Service<F, SecioKeyPair>
 where
-    F: ServiceHandle + Unpin,
+    F: ServiceHandle + Unpin + 'static,
 {
     let builder = ServiceBuilder::default()
         .insert_protocol(meta)

--- a/tentacle/tests/test_disconnect.rs
+++ b/tentacle/tests/test_disconnect.rs
@@ -11,9 +11,9 @@ use tentacle::{
     ProtocolId,
 };
 
-pub fn create<F>(secio: bool, meta: ProtocolMeta, shandle: F) -> Service<F>
+pub fn create<F>(secio: bool, meta: ProtocolMeta, shandle: F) -> Service<F, SecioKeyPair>
 where
-    F: ServiceHandle + Unpin,
+    F: ServiceHandle + Unpin + 'static,
 {
     let builder = ServiceBuilder::default().insert_protocol(meta);
 

--- a/tentacle/tests/test_kill.rs
+++ b/tentacle/tests/test_kill.rs
@@ -41,9 +41,9 @@ fn current_used_cpu() -> Option<f32> {
     }
 }
 
-pub fn create<F>(secio: bool, meta: ProtocolMeta, shandle: F) -> Service<F>
+pub fn create<F>(secio: bool, meta: ProtocolMeta, shandle: F) -> Service<F, SecioKeyPair>
 where
-    F: ServiceHandle + Unpin,
+    F: ServiceHandle + Unpin + 'static,
 {
     let builder = ServiceBuilder::default()
         .insert_protocol(meta)

--- a/tentacle/tests/test_large_pending_messge.rs
+++ b/tentacle/tests/test_large_pending_messge.rs
@@ -12,9 +12,9 @@ use tentacle::{
     ProtocolId,
 };
 
-pub fn create<F>(secio: bool, meta: ProtocolMeta, shandle: F) -> Service<F>
+pub fn create<F>(secio: bool, meta: ProtocolMeta, shandle: F) -> Service<F, SecioKeyPair>
 where
-    F: ServiceHandle + Unpin,
+    F: ServiceHandle + Unpin + 'static,
 {
     let builder = ServiceBuilder::default()
         .insert_protocol(meta)

--- a/tentacle/tests/test_peer_id.rs
+++ b/tentacle/tests/test_peer_id.rs
@@ -15,9 +15,9 @@ use tentacle::{
     ProtocolId,
 };
 
-pub fn create<F>(key_pair: SecioKeyPair, meta: ProtocolMeta, shandle: F) -> Service<F>
+pub fn create<F>(key_pair: SecioKeyPair, meta: ProtocolMeta, shandle: F) -> Service<F, SecioKeyPair>
 where
-    F: ServiceHandle + Unpin,
+    F: ServiceHandle + Unpin + 'static,
 {
     ServiceBuilder::default()
         .insert_protocol(meta)

--- a/tentacle/tests/test_priority.rs
+++ b/tentacle/tests/test_priority.rs
@@ -18,9 +18,9 @@ use tentacle::{
     ProtocolId,
 };
 
-pub fn create<F>(secio: bool, meta: ProtocolMeta, shandle: F) -> Service<F>
+pub fn create<F>(secio: bool, meta: ProtocolMeta, shandle: F) -> Service<F, SecioKeyPair>
 where
-    F: ServiceHandle + Unpin,
+    F: ServiceHandle + Unpin + 'static,
 {
     let builder = ServiceBuilder::default()
         .insert_protocol(meta)

--- a/tentacle/tests/test_protocol_open.rs
+++ b/tentacle/tests/test_protocol_open.rs
@@ -18,9 +18,9 @@ use tentacle::{
     ProtocolId,
 };
 
-pub fn create<F>(secio: bool, meta: ProtocolMeta, shandle: F) -> Service<F>
+pub fn create<F>(secio: bool, meta: ProtocolMeta, shandle: F) -> Service<F, SecioKeyPair>
 where
-    F: ServiceHandle + Unpin,
+    F: ServiceHandle + Unpin + 'static,
 {
     let builder = ServiceBuilder::default().insert_protocol(meta);
 

--- a/tentacle/tests/test_protocol_open_close_on_spawn.rs
+++ b/tentacle/tests/test_protocol_open_close_on_spawn.rs
@@ -96,9 +96,13 @@ impl ProtocolSpawn for PHandle {
     }
 }
 
-pub fn create<F>(secio: bool, metas: impl Iterator<Item = ProtocolMeta>, shandle: F) -> Service<F>
+pub fn create<F>(
+    secio: bool,
+    metas: impl Iterator<Item = ProtocolMeta>,
+    shandle: F,
+) -> Service<F, SecioKeyPair>
 where
-    F: ServiceHandle + Unpin,
+    F: ServiceHandle + Unpin + 'static,
 {
     let mut builder = ServiceBuilder::default().forever(true);
 

--- a/tentacle/tests/test_session_handle_open.rs
+++ b/tentacle/tests/test_session_handle_open.rs
@@ -69,9 +69,13 @@ impl ServiceHandle for SHandle {
     }
 }
 
-pub fn create<F>(secio: bool, metas: impl Iterator<Item = ProtocolMeta>, shandle: F) -> Service<F>
+pub fn create<F>(
+    secio: bool,
+    metas: impl Iterator<Item = ProtocolMeta>,
+    shandle: F,
+) -> Service<F, SecioKeyPair>
 where
-    F: ServiceHandle + Unpin,
+    F: ServiceHandle + Unpin + 'static,
 {
     let mut builder = ServiceBuilder::default().forever(true);
 

--- a/tentacle/tests/test_session_protocol_open_close.rs
+++ b/tentacle/tests/test_session_protocol_open_close.rs
@@ -76,9 +76,13 @@ impl SessionProtocol for PHandle {
     }
 }
 
-pub fn create<F>(secio: bool, metas: impl Iterator<Item = ProtocolMeta>, shandle: F) -> Service<F>
+pub fn create<F>(
+    secio: bool,
+    metas: impl Iterator<Item = ProtocolMeta>,
+    shandle: F,
+) -> Service<F, SecioKeyPair>
 where
-    F: ServiceHandle + Unpin,
+    F: ServiceHandle + Unpin + 'static,
 {
     let mut builder = ServiceBuilder::default().forever(true);
 

--- a/tentacle/tests/test_tls_reconnect.rs
+++ b/tentacle/tests/test_tls_reconnect.rs
@@ -3,6 +3,7 @@ use crossbeam_channel::Receiver;
 use rustls_pemfile::{certs, pkcs8_private_keys, rsa_private_keys};
 use std::io::BufReader;
 use std::str::FromStr;
+use std::sync::Arc;
 use std::time::Duration;
 use std::{fs, thread};
 use tentacle::bytes::Bytes;
@@ -23,9 +24,9 @@ use tokio_rustls::rustls::{
     SupportedProtocolVersion, ALL_CIPHER_SUITES,
 };
 
-pub fn create<F>(meta: ProtocolMeta, shandle: F, cert_path: String) -> Service<F>
+pub fn create<F>(meta: ProtocolMeta, shandle: F, cert_path: String) -> Service<F, ()>
 where
-    F: ServiceHandle + Unpin,
+    F: ServiceHandle + Unpin + 'static,
 {
     let mut builder = ServiceBuilder::default()
         .insert_protocol(meta)
@@ -215,7 +216,7 @@ pub fn make_server_config(config: &NetConfig) -> ServerConfig {
     for cacert in &cacerts {
         client_auth_roots.add(cacert).unwrap();
     }
-    let client_auth = AllowAnyAuthenticatedClient::new(client_auth_roots);
+    let client_auth = Arc::new(AllowAnyAuthenticatedClient::new(client_auth_roots));
 
     let server_config = server_config.with_client_cert_verifier(client_auth);
 

--- a/tentacle/tests/test_uninterrupter_poll.rs
+++ b/tentacle/tests/test_uninterrupter_poll.rs
@@ -47,9 +47,9 @@ fn create_meta(id: ProtocolId) -> ProtocolMeta {
         .build()
 }
 
-pub fn create<F>(meta: ProtocolMeta, shandle: F) -> Service<F>
+pub fn create<F>(meta: ProtocolMeta, shandle: F) -> Service<F, ()>
 where
-    F: ServiceHandle + Unpin,
+    F: ServiceHandle + Unpin + 'static,
 {
     ServiceBuilder::default()
         .insert_protocol(meta)


### PR DESCRIPTION
This is a feature with a wide influence and break change. I have tried several methods, and finally feel that the current writing method is relatively appropriate.

It will allow users to decide how to keep the private key used for ecdh, such as using some private key management services, requiring network communication signatures, and of course a default implementation is also provided. Users don't even need to use the secp256k1 algorithm, such as ed25519, as long as they conform to the behavior specification of the trait.

Of course, it also contains some minor modifications, including api changes, etc.