### PR TITLE
chore: add Display impl for PeerId

### DIFF
--- a/secio/src/peer_id.rs
+++ b/secio/src/peer_id.rs
@@ -111,6 +111,12 @@ impl fmt::Debug for PeerId {
     }
 }
 
+impl fmt::Display for PeerId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.to_base58())
+    }
+}
+
 impl From<PublicKey> for PeerId {
     #[inline]
     fn from(key: PublicKey) -> PeerId {


### PR DESCRIPTION
This PR added Display trait impl for PeerId, make it easier to co-work with `serde`

```
#[serde_as]
#[derive(Serialize, Deserialize)]
pub struct Foo {
    #[serde_as(as = "DisplayFromStr")]
    peer_id: PeerId,
    ...
}
```