### PR TITLE
fix: temporary value dropped while borrowed

### DIFF
--- a/tentacle/src/protocol_handle_stream.rs
+++ b/tentacle/src/protocol_handle_stream.rs
@@ -249,7 +249,7 @@ where
                 Some(token) = self.notify_receiver.next() => {
                     self.handle_event(ServiceProtocolEvent::Notify { token }).await;
                 },
-                res = &mut self.handle.poll(&mut self.handle_context), if self.need_poll => {
+                res = self.handle.poll(&mut self.handle_context), if self.need_poll => {
                     self.need_poll = res.is_some();
                 },
                 _ = &mut recv => break,


### PR DESCRIPTION
compiling bug

line number if from old version
```
error[E0716]: temporary value dropped while borrowed
   --> /home/ypf/.cargo/git/checkouts/tentacle-ac0fddddf0c1bd2b/f71c143/tentacle/src/protocol_handle_stream.rs:252:28
    |
239 | /             tokio::select! {
240 | |                 event = self.receiver.next() => {
241 | |                     match event {
242 | |                         Some(event) => self.handle_event(event).await,
...   |
252 | |                 res = &mut self.handle.poll(&mut self.handle_context), if self.need_poll => {
    | |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary value which is freed while still in use
...   |
256 | |                 else => break
257 | |             }
    | |             -
    | |             |
    | |_____________temporary value is freed at the end of this statement
    |               borrow later used here
    |
    = note: consider using a `let` binding to create a longer lived value
```